### PR TITLE
try fix storage change for op SLOAD

### DIFF
--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -781,6 +781,13 @@ class LaserEVM:
                     data = gblState.accounts[gblState.environment.sender].storage[index]
                 except KeyError:
                     data = BitVec("storage_" + str(index), 256)
+                    
+                    # Should create a fresh copy of account object like 'SSTORE' op
+                    for k in gblState.accounts:
+                        if gblState.accounts[k] == gblState.environment.active_account:
+                            gblState.accounts[k] = copy.deepcopy(gblState.accounts[k])
+                            gblState.environment.active_account = gblState.accounts[k]
+                            break
                     gblState.environment.active_account.storage[index] = data
 
                 state.stack.append(data)


### PR DESCRIPTION
Should create a fresh copy of account object like `SSTORE` op.

If not, the storage change caused by `SLOAD` op will be wrongly applied to the `environment` and `accounts` object of all states in previous nodes.