### PR TITLE
fix op implemention about contract function call

### DIFF
--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -678,6 +678,9 @@ class LaserEVM:
                 addr = state.stack.pop()
                 start, s2, size = state.stack.pop(), state.stack.pop(), state.stack.pop()
 
+            elif op == 'RETURNDATASIZE':
+                state.stack.append(BitVec("returndatasize", 256))
+
             elif op == 'BLOCKHASH':
                 blocknumber = state.stack.pop()
                 state.stack.append(BitVec("blockhash_block_" + str(blocknumber), 256))
@@ -986,6 +989,8 @@ class LaserEVM:
                     else:
                         ret = BitVec("retval_" + str(instr['address']), 256)
                         state.stack.append(ret)
+                        # Set output memory
+                        state.memory[memoutstart] = ret
                         continue
 
                 if not re.match(r"^0x[0-9a-f]{40}", callee_address):

--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -990,6 +990,7 @@ class LaserEVM:
                         ret = BitVec("retval_" + str(instr['address']), 256)
                         state.stack.append(ret)
                         # Set output memory
+                        state.mem_extend(memoutstart, 1)
                         state.memory[memoutstart] = ret
                         continue
 


### PR DESCRIPTION
**See contract comments.**

```solidity
pragma solidity ^0.4.18;

contract A {
    uint x;
    function a(uint input) public returns(uint) {
        require(input > 10);
        x = input;
        return x;
    }
}

contract B {
    uint x;
    address delegateAddress;
    function b(uint input) public {
        require(input > 10);
        x = input;
    }

    function b_call_a(uint input) public {
        A delegate = A(delegateAddress);
        var ret = delegate.a(input);
        // laser could not simulate these two branches
        // after library function call due to chaotic stack and memory
        if (ret > 20) {
            x = ret + 9;
        } else {
            x = ret + 10;
        }
    }
}
```

Two graph generated for comparison.

- [call_ret_value.origin.graph.html](http://htmlpreview.github.io/?https://gist.githubusercontent.com/p0n1/85595d3ce0fab4c0c3ce987b3a2e6169/raw/c92c236753969f2825df8c501388858186593547/call_ret_value.graph.html)

- [call_ret_value.improved.graph.html](http://htmlpreview.github.io/?https://gist.githubusercontent.com/p0n1/ea6831075846d1502a91e54027865a55/raw/44a7a84904a4a55fc03511a8e63679ff809d2df5/call_ret_value.improve.graph.html)


This commit do as follows:

- Add `RETURNDATASIZE` op: missing this caused misplaced stack after contract function call.

- Set output memory for `CALL` & `CALLCODE` op: should store call `retval` to memory, otherwise wrong value will be `MLOAD` from mem.

TODOs:

- [ ] Not sure this fix will break other code or not.

- [ ] This [if branch](https://github.com/b-mueller/laser-ethereum/blob/8759492ba1e2c9cb9e5d3fae589ede9f7827a31c/laser/ethereum/svm.py#L946) is complicated and could forget to store `retval` to memory in several places.

