### PR TITLE
Add the basic support for BYTE opcode

### DIFF
--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -391,7 +391,15 @@ class LaserEVM:
             elif op == 'BYTE':
                 s0, s1 = state.stack.pop(), state.stack.pop()
 
-                state.stack.append(BitVecVal(0, 256))
+                try:
+                    n = helper.get_concrete_int(s0)
+                    oft = (31 - n) * 8
+                    result = Concat(BitVecVal(0, 248), Extract(oft + 7, oft, s1))
+                except AttributeError:
+                    logging.debug("BYTE: Unsupported symbolic byte offset")
+                    result = BitVec(str(simplify(s1)) + "_" + str(simplify(s0)), 256)
+
+                state.stack.append(simplify(result))
 
             # Arithmetics
 


### PR DESCRIPTION
This pull request adds the basic support for BYTE opcode. The symbolic byte offset is however not supported yet.