### PR TITLE
Make depth and constraints variables part of a state

### DIFF
--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -261,8 +261,6 @@ class LaserEVM:
         )
 
         gblState = GlobalState(self.accounts, environment)
-        gblState.mstate.constraints = []
-        gblState.mstate.depth = 0
 
         node = self._sym_exec(gblState)
         self.nodes[node.uid] = node
@@ -1095,7 +1093,7 @@ class LaserEVM:
                     callee_environment = Environment(callee_account, BitVecVal(int(environment.active_account.address, 16), 256), calldata, environment.gasprice, value, environment.origin, calldata_type=calldata_type)
                     new_gblState = GlobalState(gblState.accounts, callee_environment, MachineState(gas))
                     new_gblState.mstate.depth = new_gblState.mstate.depth + 1
-                    new_gblState.mstate.constraints = state.constraints
+                    new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)
 
@@ -1113,7 +1111,7 @@ class LaserEVM:
 
                     new_gblState = GlobalState(gblState.accounts, environment, MachineState(gas))
                     new_gblState.mstate.depth = new_gblState.mstate.depth + 1
-                    new_gblState.mstate.constraints = state.constraints
+                    new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)
                     self.nodes[new_node.uid] = new_node
@@ -1131,7 +1129,7 @@ class LaserEVM:
 
                     new_gblState = GlobalState(gblState.accounts, environment, MachineState(gas))
                     new_gblState.mstate.depth = new_gblState.mstate.depth + 1
-                    new_gblState.mstate.constraints = state.constraints
+                    new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)
                     self.nodes[new_node.uid] = new_node

--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -849,7 +849,7 @@ class LaserEVM:
 
                         new_gblState = self.copy_global_state(gblState)
                         new_gblState.mstate.pc = i
-                        new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                        new_gblState.mstate.depth += 1
 
                         new_node = self._sym_exec(new_gblState)
                         self.nodes[new_node.uid] = new_node
@@ -899,7 +899,7 @@ class LaserEVM:
                                 new_gblState = self.copy_global_state(gblState)
                                 new_gblState.mstate.pc = i
                                 new_gblState.mstate.constraints.append(condition)
-                                new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                                new_gblState.mstate.depth += 1
 
                                 new_node = self._sym_exec(new_gblState)
                                 self.nodes[new_node.uid] = new_node
@@ -1151,7 +1151,7 @@ class LaserEVM:
                 return_address = self.call_stack.pop()
 
                 new_gblState = self.copy_global_state(gblState)
-                new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                new_gblState.mstate.depth += 1
                 new_node = self._sym_exec(new_gblState)
                 new_node.flags |= NodeFlags.CALL_RETURN
 

--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -1092,7 +1092,7 @@ class LaserEVM:
 
                     callee_environment = Environment(callee_account, BitVecVal(int(environment.active_account.address, 16), 256), calldata, environment.gasprice, value, environment.origin, calldata_type=calldata_type)
                     new_gblState = GlobalState(gblState.accounts, callee_environment, MachineState(gas))
-                    new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                    new_gblState.mstate.depth = state.depth + 1
                     new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)
@@ -1110,7 +1110,7 @@ class LaserEVM:
                     environment.calldata = calldata
 
                     new_gblState = GlobalState(gblState.accounts, environment, MachineState(gas))
-                    new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                    new_gblState.mstate.depth = state.depth + 1
                     new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)
@@ -1128,7 +1128,7 @@ class LaserEVM:
                     environment.calldata = calldata
 
                     new_gblState = GlobalState(gblState.accounts, environment, MachineState(gas))
-                    new_gblState.mstate.depth = new_gblState.mstate.depth + 1
+                    new_gblState.mstate.depth = state.depth + 1
                     new_gblState.mstate.constraints = copy.deepcopy(state.constraints)
 
                     new_node = self._sym_exec(new_gblState)

--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -280,7 +280,7 @@ class LaserEVM:
             self.current_func = "fallback"
             self.current_func_addr = start_addr
 
-        node = Node(environment.active_account.contract_name, start_addr, state.constraints)
+        node = Node(environment.active_account.contract_name, start_addr, copy.deepcopy(state.constraints))
 
         logging.debug("- Entering node " + str(node.uid) + ", index = " + str(state.pc) + ", address = " + str(start_addr) + ", depth = " + str(state.depth))
 


### PR DESCRIPTION
Store `depth` and `constraints` as fields in a state rather than passing them as separate parameters to `_sym_exec`. The purpose of this refactoring is to prepare for the restructuring of `sym_exec` as a state-worklist loop rather than recursion.

