### PR TITLE
svm: bugfix for symbolic memory index in op CALL & CALLCODE

### DIFF
--- a/laser/ethereum/svm.py
+++ b/laser/ethereum/svm.py
@@ -992,8 +992,12 @@ class LaserEVM:
                         ret = BitVec("retval_" + str(instr['address']), 256)
                         state.stack.append(ret)
                         # Set output memory
-                        state.mem_extend(memoutstart, 1)
-                        state.memory[memoutstart] = ret
+                        logging.debug("memoutstart: "+ str(memoutstart))
+                        if not isinstance(memoutstart, ExprRef):
+                            state.mem_extend(memoutstart, 1)
+                            state.memory[memoutstart] = ret
+                        else:
+                            logging.warning("Unsupported memory symbolic index")
                         continue
 
                 if not re.match(r"^0x[0-9a-f]{40}", callee_address):


### PR DESCRIPTION
laser does not support symbolic memory index by now.
It's a quick fix for memory index represented by z3 expr.
But of course, the corret value could not MLOAD from memory
for this situation. Memory and storage management is still
needed to improve.

This commit should fix [Mythril issue 199](https://github.com/ConsenSys/mythril/issues/199).